### PR TITLE
:bug: 修复 Layout-Header 中英文切换和主题色切换混 #3

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Layout, Menu, theme, Avatar, Dropdown, ConfigProvider, Badge, Popover, type MenuProps } from 'antd';
 import getNavList from './menu';
 import { useRouter } from 'next/navigation';
@@ -22,6 +22,10 @@ interface IProps {
     defaultOpen?: string[]
 }
 
+const onLogout = () => {
+    localStorage.removeItem("isDarkTheme")
+}
+
 const items: MenuProps['items'] = [
     {
       key: '1',
@@ -42,7 +46,7 @@ const items: MenuProps['items'] = [
     {
       key: '3',
       label: (
-        <a target="_blank" rel="noopener noreferrer" href="/user/login">
+        <a target="_blank" onClick={onLogout} rel="noopener noreferrer" href="/user/login">
           退出登录
         </a>
       ),
@@ -65,12 +69,19 @@ const CommonLayout: React.FC<IProps> = ({ children, curActive, defaultOpen = ['/
 
   const [curTheme, setCurTheme] = useState<boolean>(false);
   const toggleTheme = () => {
-        setCurTheme(prev => !prev);
+        const _curTheme = !curTheme;
+        setCurTheme(_curTheme);
+        localStorage.setItem('isDarkTheme', _curTheme ? 'true' : '');
   }
 
   const handleSelect = (row: {key: string}) => {
     router.push(row.key)
   }
+
+  useEffect(() => {
+      const isDark = !!localStorage.getItem("isDarkTheme");
+      setCurTheme(isDark);
+  }, []);
 
   return (
     <ConfigProvider


### PR DESCRIPTION
## Layout-Header

### fix

1. 修复 黑暗主题时, 切换中英主题恢复到默认主题 


#### 相关issue #3
### 原因

切换中英时更改了路由, 导致组件重新加载, 主题变量恢复到了默认值

### 解决方案
将主题变量缓存, 组件重新加载时读取缓存主题